### PR TITLE
Enable searching in Japanese

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,7 +16,7 @@ theme:
 
 extra:
   search:
-    language: 'jp'
+    language: 'ja'
 
 markdown_extensions:
   - 'admonition'


### PR DESCRIPTION
日本語で検索できない問題の修正です。

https://github.com/squidfunk/mkdocs-material/issues/1023
squidfunk/mkdocs-material の4.0.2では不具合があったようで、Issueがありました。

https://github.com/squidfunk/mkdocs-material/issues/1038#issuecomment-475733437
最新の4.1.0では直っていて、 `jp` ではなく `ja` でよくなっているみたいなので修正しました。